### PR TITLE
Share the full original Citadel module

### DIFF
--- a/citadel/citadel.py
+++ b/citadel/citadel.py
@@ -1,5 +1,7 @@
 import logging
+import malduck
 
+from malduck import disasm, p32
 from malduck.extractor import Extractor
 
 log = logging.getLogger(__name__)
@@ -10,7 +12,7 @@ __version__ = "1.0.0"
 class Citadel(Extractor):
 
     """
-    Citadel Configuration Extracto
+    Citadel Configuration Extractor
     """
     
     family     = "citadel"
@@ -21,14 +23,15 @@ class Citadel(Extractor):
         log.info('[+] `Coded by Brian Krebs` str @ %X' % addr)
         return {'family': 'citadel'}
 
+    @Extractor.weak
     @Extractor.extractor
     def cit_salt(self, p, addr):
         salt = p.uint32v(addr - 8)
         log.info('[+] Found salt @ %X - %x' % (addr, salt))
         return {'salt': salt}
 
-    @Extractor.string
-    def cit_login(self, p, addr, match):
+    @Extractor.extractor
+    def cit_login(self, p, addr):
         log.info('[+] Found login_key xor @ %X' % addr)
         hit = p.uint32v(addr + 4)
         if p.is_addr(hit):
@@ -36,3 +39,36 @@ class Citadel(Extractor):
         hit = p.uint32v(addr + 5)
         if p.is_addr(hit):
             return {'login_key': p.asciiz(hit)}
+
+    @Extractor.extractor
+    def cit_aes_xor(self, p, addr):
+        log.info('[+] Found aes_xor key @ %X' % addr)
+        r = []
+        for c in disasm(p.readv(addr, 40), addr):
+            if len(r) == 4:
+                break
+            if c.mnem == 'xor':
+                r.append(c.op2.value)
+        return {'aes_xor': malduck.enhex(b''.join(map(p32, r)))}
+
+    @Extractor.weak
+    @Extractor.extractor
+    def cit_getpes(self, p, addr):
+        log.info('[+] pesettings found near @ %X' % addr)
+        oss = []
+        for c in disasm(p.readv(addr-20, 100), addr-20):
+            if len(oss) == 2:
+                break
+            elif c.mnem == 'lea':
+                oss.append(abs(c.op2.value))
+
+        off = oss[0] - oss[1]
+        return {'key_off': abs(off)}
+
+    @Extractor.weak
+    @Extractor.extractor
+    def cit_base_off(self, p, addr):
+        var_bc = int(p.uint32v(addr + 3))
+        var_lk = int(p.uint32v(addr + 30))
+        offset = var_bc - var_lk
+        return {'key_off': abs(offset)}


### PR DESCRIPTION
Share the full version of CERT.PL's Citadel module.

This is probably not the most useful module to have (Citadel's best years are behind it), but it demonstrates a few nice Malduck features.

Before:

```
$ malduck extract --modules mwcfg-modules/ /tmp/tmp.f8C2KIJfw5/citadelmalware.bin
[+] Ripped 'citadel' from /tmp/tmp.f8C2KIJfw5/citadelmalware.bin:
{
    "family": "citadel",
    "login_key": "B",
    "salt": 4073311727
}
```

After:

```
$ malduck extract --modules mwcfg-modules/ /tmp/tmp.f8C2KIJfw5/citadelmalware.bin
[+] Ripped 'citadel' from /tmp/tmp.f8C2KIJfw5/citadelmalware.bin:
{
    "aes_xor": "3e4abb01841bb298122bb5efb1bed171",
    "family": "citadel",
    "key_off": 343,
    "login_key": "B",
    "salt": 4073311727
}
```